### PR TITLE
Update profile form to use shared UI components

### DIFF
--- a/code/frontend/frp-fe/src/components/UIComponent/Button.tsx
+++ b/code/frontend/frp-fe/src/components/UIComponent/Button.tsx
@@ -50,3 +50,12 @@ export function LogoutButton({loading, ...props}: { loading: boolean } & Omit<Bu
         </Button>
     );
 }
+
+export function ProfileButton({loading, ...props}: { loading: boolean } & Omit<ButtonProps, "children">) {
+    const {t} = useTranslation();
+    return (
+        <Button {...props} variant="primary" disabled={loading}>
+            {loading ? t("profile.button-progress") : t("profile.button")}
+        </Button>
+    );
+}

--- a/code/frontend/frp-fe/src/components/UIComponent/Input.tsx
+++ b/code/frontend/frp-fe/src/components/UIComponent/Input.tsx
@@ -97,3 +97,27 @@ export function InputPassword(
         />
     );
 }
+
+export function InputNewPassword(
+    props: Readonly<Omit<
+        BaseInputProps,
+        | "type"
+        | "labelTranslationKey"
+        | "placeholderTranslationKey"
+        | "name"
+        | "id"
+        | "autoComplete"
+    >>
+) {
+    return (
+        <BaseInput
+            type="password"
+            labelTranslationKey="profile.password"
+            placeholderTranslationKey="profile.password"
+            name="password"
+            id="password"
+            autoComplete="new-password"
+            {...props}
+        />
+    );
+}

--- a/code/frontend/frp-fe/src/components/UIComponent/Text.tsx
+++ b/code/frontend/frp-fe/src/components/UIComponent/Text.tsx
@@ -33,6 +33,14 @@ export function TextError({message}: Readonly<{ message: string }>) {
     );
 }
 
+export function TextSuccess({message}: Readonly<{ message: string }>) {
+    return (
+        <div className="text-green-600 text-sm text-center my-2">
+            {message}
+        </div>
+    );
+}
+
 export function Paragraph({children}: Readonly<{ children: React.ReactNode }>) {
     return (
         <p className="text-textPrimary text-base leading-relaxed mb-4">

--- a/code/frontend/frp-fe/src/components/UserManagement/ProfileEditForm.tsx
+++ b/code/frontend/frp-fe/src/components/UserManagement/ProfileEditForm.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { UserManagementService } from "../../api/services/UserManagementService";
 import type { UserDto } from "../../api/models/UserDto";
+import { Form } from "../UIComponent/Form.tsx";
+import { H2Title, TextError, TextSuccess } from "../UIComponent/Text.tsx";
+import { InputText, InputEmail, InputNewPassword } from "../UIComponent/Input.tsx";
+import { ProfileButton } from "../UIComponent/Button.tsx";
 import { useTranslation } from "react-i18next";
 
 export const ProfileEditForm: React.FC<{ onProfileUpdate?: (user: UserDto) => void }> = ({ onProfileUpdate }) => {
@@ -42,36 +46,34 @@ export const ProfileEditForm: React.FC<{ onProfileUpdate?: (user: UserDto) => vo
     };
 
     return (
-        <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-8 p-6 bg-white shadow-xl rounded-lg flex flex-col gap-4">
-            <h2 className="text-xl font-semibold text-center">{t("profile.title")}</h2>
-            <input
-                className="border rounded p-2"
-                type="text"
-                placeholder={t("profile.fullName")}
+        <Form onSubmit={handleSubmit}>
+            <H2Title>{t("profile.title")}</H2Title>
+
+            <InputText
+                id="fullName"
+                name="fullName"
+                placeholderTranslationKey="profile.fullName"
+                labelTranslationKey="profile.fullName"
                 value={fullName}
                 required
                 onChange={e => setFullName(e.target.value)}
             />
-            <input
-                className="border rounded p-2"
-                type="email"
-                placeholder={t("profile.email")}
+
+            <InputEmail
                 value={email}
                 required
                 onChange={e => setEmail(e.target.value)}
             />
-            <input
-                className="border rounded p-2"
-                type="password"
-                placeholder={t("profile.password")}
+
+            <InputNewPassword
                 value={password}
                 onChange={e => setPassword(e.target.value)}
             />
-            {error && <div className="text-red-600 text-sm">{error}</div>}
-            {success && <div className="text-green-600 text-sm">{success}</div>}
-            <button type="submit" disabled={loading} className="bg-blue-600 text-white rounded p-2 hover:bg-blue-700">
-                {loading ? t("profile.button-progress") : t("profile.button")}
-            </button>
-        </form>
+
+            {error && <TextError message={error} />}
+            {success && <TextSuccess message={success} />}
+
+            <ProfileButton loading={loading} type="submit" />
+        </Form>
     );
 };


### PR DESCRIPTION
## Summary
- add `InputNewPassword` for profile password field
- add `TextSuccess` for success messages
- add `ProfileButton` with translated label
- rewrite `ProfileEditForm` to use shared components

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6884d30ce4088329894873daa5894aca